### PR TITLE
XIVY-3774 Upgrade build-plugin to 8.0.5-SNAP and projects to 9.1.0-SNAP

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,6 +33,7 @@ pipeline {
       }
       post {
         always {
+          recordIssues tools: [mavenConsole()], unstalbeTotalAll: 1
           junit '**/**/target/surefire-reports/**/*.xml'
         }
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,7 +33,7 @@ pipeline {
       }
       post {
         always {
-          recordIssues tools: [mavenConsole()], unstalbeTotalAll: 1
+          recordIssues tools: [mavenConsole()], unstableTotalAll: 1
           junit '**/**/target/surefire-reports/**/*.xml'
         }
       }

--- a/compile-test/crm.maven/config/pom.xml
+++ b/compile-test/crm.maven/config/pom.xml
@@ -28,7 +28,7 @@
 					<groupId>com.axonivy.ivy.ci</groupId>
 					<artifactId>project-build-plugin</artifactId>
 					<!-- pre-configure the exact version to use for child projects -->
-					<version>8.0.3</version>
+					<version>8.0.5-SNAPSHOT</version>
 				</plugin>
 			</plugins>
 		</pluginManagement>

--- a/compile-test/crm.maven/config/pom.xml
+++ b/compile-test/crm.maven/config/pom.xml
@@ -28,7 +28,11 @@
 					<groupId>com.axonivy.ivy.ci</groupId>
 					<artifactId>project-build-plugin</artifactId>
 					<!-- pre-configure the exact version to use for child projects -->
-					<version>8.0.5-SNAPSHOT</version>
+					<version>9.1.0-SNAPSHOT</version>
+					<configuration>
+						<!-- 9.1.0 has not been released yet, using the nightly build -->
+						<engineDownloadUrl>https://developer.axonivy.com/permalink/nightly/axonivy-engine.zip</engineDownloadUrl>
+					</configuration>
 				</plugin>
 			</plugins>
 		</pluginManagement>

--- a/deploy/application/README.MD
+++ b/deploy/application/README.MD
@@ -61,7 +61,7 @@ Via the deploy-to-engine goal it deploys this zip with all projects to a running
 <plugin>
   <groupId>com.axonivy.ivy.ci</groupId>
   <artifactId>project-build-plugin</artifactId>
-  <version>8.0.5-SNAPSHOT</version>
+  <version>9.1.0-SNAPSHOT</version>
   <executions>
     <execution>
       <id>deploy.to.staging</id>

--- a/deploy/application/README.MD
+++ b/deploy/application/README.MD
@@ -61,7 +61,7 @@ Via the deploy-to-engine goal it deploys this zip with all projects to a running
 <plugin>
   <groupId>com.axonivy.ivy.ci</groupId>
   <artifactId>project-build-plugin</artifactId>
-  <version>7.4.0-SNAPSHOT</version>
+  <version>8.0.5-SNAPSHOT</version>
   <executions>
     <execution>
       <id>deploy.to.staging</id>

--- a/deploy/application/base/pom.xml
+++ b/deploy/application/base/pom.xml
@@ -4,12 +4,12 @@
   <parent>
     <groupId>ch.ivyteam.ivy.project.demo.ci.deploy.application</groupId>
     <artifactId>maven.config</artifactId>
-    <version>7.3.0-SNAPSHOT</version>
+    <version>9.1.0-SNAPSHOT</version>
     <relativePath>../maven/config</relativePath>
   </parent>
   <groupId>ch.ivyteam.ivy.project.demo.ci.deploy.application</groupId>
   <artifactId>base</artifactId>
-  <version>7.3.0-SNAPSHOT</version>
+  <version>9.1.0-SNAPSHOT</version>
   <packaging>iar</packaging>
   <description>sample project for illustrative purposes. Implement db interactions and provides simple domain objects.</description>
 </project>

--- a/deploy/application/customer/pom.xml
+++ b/deploy/application/customer/pom.xml
@@ -4,18 +4,18 @@
   <parent>
     <groupId>ch.ivyteam.ivy.project.demo.ci.deploy.application</groupId>
     <artifactId>maven.config</artifactId>
-    <version>7.3.0-SNAPSHOT</version>
+    <version>9.1.0-SNAPSHOT</version>
     <relativePath>../maven/config</relativePath>
   </parent>
   <groupId>ch.ivyteam.ivy.project.demo.ci.deploy.application</groupId>
   <artifactId>customer</artifactId>
-  <version>7.3.0-SNAPSHOT</version>
+  <version>9.1.0-SNAPSHOT</version>
   <packaging>iar</packaging>
   <dependencies>
     <dependency>
       <groupId>ch.ivyteam.ivy.project.demo.ci.deploy.application</groupId>
       <artifactId>solution</artifactId>
-      <version>[7.3.0-SNAPSHOT,)</version>
+      <version>[9.1.0-SNAPSHOT,)</version>
       <type>iar</type>
     </dependency>
   </dependencies>

--- a/deploy/application/maven/config/pom.xml
+++ b/deploy/application/maven/config/pom.xml
@@ -32,8 +32,12 @@
       <plugin>
         <groupId>com.axonivy.ivy.ci</groupId>
         <artifactId>project-build-plugin</artifactId>
-        <version>8.0.5-SNAPSHOT</version>
+        <version>9.1.0-SNAPSHOT</version>
         <extensions>true</extensions>
+        <configuration>
+          <!-- 9.1.0 has not been released yet, using the nightly build -->
+          <engineDownloadUrl>https://developer.axonivy.com/permalink/nightly/axonivy-engine.zip</engineDownloadUrl>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/deploy/application/maven/config/pom.xml
+++ b/deploy/application/maven/config/pom.xml
@@ -1,41 +1,41 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
-	xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-	<modelVersion>4.0.0</modelVersion>
-	<groupId>ch.ivyteam.ivy.project.demo.ci.deploy.application</groupId>
-	<artifactId>maven.config</artifactId>
-	<version>7.3.0-SNAPSHOT</version>
-	<packaging>pom</packaging>
-	<organization>
-		<name>AXON Ivy AG</name>
-	</organization>
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+  xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>ch.ivyteam.ivy.project.demo.ci.deploy.application</groupId>
+  <artifactId>maven.config</artifactId>
+  <version>9.1.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+  <organization>
+    <name>AXON Ivy AG</name>
+  </organization>
 
-	<properties>
+  <properties>
     <maven.deploy.skip>true</maven.deploy.skip>
   </properties>
 
-	<pluginRepositories>
-		<!-- Snapshot releases are not deployed to maven central. So the repo on 
-			sonatype could be used instead -->
-		<pluginRepository>
-			<id>sonatype</id>
-			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
-			<snapshots>
-				<updatePolicy>always</updatePolicy>
-			</snapshots>
-		</pluginRepository>
-	</pluginRepositories>
+  <pluginRepositories>
+    <!-- Snapshot releases are not deployed to maven central. So the repo on 
+      sonatype could be used instead -->
+    <pluginRepository>
+      <id>sonatype</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <snapshots>
+        <updatePolicy>always</updatePolicy>
+      </snapshots>
+    </pluginRepository>
+  </pluginRepositories>
 
   <build>
     <plugins>
       <plugin>
         <groupId>com.axonivy.ivy.ci</groupId>
         <artifactId>project-build-plugin</artifactId>
-        <version>7.4.1-SNAPSHOT</version>
+        <version>8.0.5-SNAPSHOT</version>
         <extensions>true</extensions>
       </plugin>
     </plugins>
   </build>
-	
+
 </project>

--- a/deploy/application/pom.xml
+++ b/deploy/application/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>ch.ivyteam.ivy.project.demo.ci.deploy.application</groupId>
 	<artifactId>application</artifactId>
-	<version>7.3.0-SNAPSHOT</version>
+	<version>9.1.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<scm>
@@ -46,7 +46,7 @@
 			<plugin>
 				<groupId>com.axonivy.ivy.ci</groupId>
 				<artifactId>project-build-plugin</artifactId>
-				<version>7.4.1-SNAPSHOT</version>
+				<version>8.0.5-SNAPSHOT</version>
 				<executions>
 					<execution>
 						<id>test.engine.starter</id>

--- a/deploy/application/pom.xml
+++ b/deploy/application/pom.xml
@@ -46,7 +46,7 @@
 			<plugin>
 				<groupId>com.axonivy.ivy.ci</groupId>
 				<artifactId>project-build-plugin</artifactId>
-				<version>8.0.5-SNAPSHOT</version>
+				<version>9.1.0-SNAPSHOT</version>
 				<executions>
 					<execution>
 						<id>test.engine.starter</id>

--- a/deploy/application/solution/pom.xml
+++ b/deploy/application/solution/pom.xml
@@ -4,19 +4,19 @@
   <parent>
     <groupId>ch.ivyteam.ivy.project.demo.ci.deploy.application</groupId>
     <artifactId>maven.config</artifactId>
-    <version>7.3.0-SNAPSHOT</version>
+    <version>9.1.0-SNAPSHOT</version>
     <relativePath>../maven/config</relativePath>
   </parent>
   <groupId>ch.ivyteam.ivy.project.demo.ci.deploy.application</groupId>
   <artifactId>solution</artifactId>
-  <version>7.3.0-SNAPSHOT</version>
+  <version>9.1.0-SNAPSHOT</version>
   <packaging>iar</packaging>
   <description>implements a generic solution</description>
   <dependencies>
     <dependency>
       <groupId>ch.ivyteam.ivy.project.demo.ci.deploy.application</groupId>
       <artifactId>base</artifactId>
-      <version>[7.3.0-SNAPSHOT,)</version>
+      <version>[9.1.0-SNAPSHOT,)</version>
       <type>iar</type>
     </dependency>
   </dependencies>

--- a/deploy/config-application/README.MD
+++ b/deploy/config-application/README.MD
@@ -68,7 +68,7 @@ Via the deploy-to-engine goal it deploys this zip with all projects to a running
 <plugin>
   <groupId>com.axonivy.ivy.ci</groupId>
   <artifactId>project-build-plugin</artifactId>
-  <version>8.0.5-SNAPSHOT</version>
+  <version>9.1.0-SNAPSHOT</version>
   <executions>
     <execution>
       <id>deploy.to.staging</id>

--- a/deploy/config-application/README.MD
+++ b/deploy/config-application/README.MD
@@ -68,7 +68,7 @@ Via the deploy-to-engine goal it deploys this zip with all projects to a running
 <plugin>
   <groupId>com.axonivy.ivy.ci</groupId>
   <artifactId>project-build-plugin</artifactId>
-  <version>7.4.0-SNAPSHOT</version>
+  <version>8.0.5-SNAPSHOT</version>
   <executions>
     <execution>
       <id>deploy.to.staging</id>

--- a/deploy/config-application/configViewer/pom.xml
+++ b/deploy/config-application/configViewer/pom.xml
@@ -4,12 +4,12 @@
   <parent>
     <groupId>ch.ivyteam.ivy.project.demo.ci.deploy.config-application</groupId>
     <artifactId>maven.config</artifactId>
-    <version>7.3.0-SNAPSHOT</version>
+    <version>9.1.0-SNAPSHOT</version>
     <relativePath>../maven/config</relativePath>
   </parent>
   <groupId>ch.ivyteam.ivy.project.demo.ci.deploy.config-application</groupId>
   <artifactId>configViewer</artifactId>
-  <version>7.3.0-SNAPSHOT</version>
+  <version>9.1.0-SNAPSHOT</version>
   <packaging>iar</packaging>
   <description>sample project for view application configurations. override them in the app.yaml file.</description>
 </project>

--- a/deploy/config-application/maven/config/pom.xml
+++ b/deploy/config-application/maven/config/pom.xml
@@ -1,41 +1,41 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
-	xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-	<modelVersion>4.0.0</modelVersion>
-	<groupId>ch.ivyteam.ivy.project.demo.ci.deploy.config-application</groupId>
-	<artifactId>maven.config</artifactId>
-	<version>7.3.0-SNAPSHOT</version>
-	<packaging>pom</packaging>
-	<organization>
-		<name>AXON Ivy AG</name>
-	</organization>
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+  xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>ch.ivyteam.ivy.project.demo.ci.deploy.config-application</groupId>
+  <artifactId>maven.config</artifactId>
+  <version>9.1.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+  <organization>
+    <name>AXON Ivy AG</name>
+  </organization>
 
-	<properties>
+  <properties>
     <maven.deploy.skip>true</maven.deploy.skip>
   </properties>
 
-	<pluginRepositories>
-		<!-- Snapshot releases are not deployed to maven central. So the repo on 
-			sonatype could be used instead -->
-		<pluginRepository>
-			<id>sonatype</id>
-			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
-			<snapshots>
-				<updatePolicy>always</updatePolicy>
-			</snapshots>
-		</pluginRepository>
-	</pluginRepositories>
+  <pluginRepositories>
+    <!-- Snapshot releases are not deployed to maven central. So the repo on 
+      sonatype could be used instead -->
+    <pluginRepository>
+      <id>sonatype</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <snapshots>
+        <updatePolicy>always</updatePolicy>
+      </snapshots>
+    </pluginRepository>
+  </pluginRepositories>
 
   <build>
     <plugins>
       <plugin>
         <groupId>com.axonivy.ivy.ci</groupId>
         <artifactId>project-build-plugin</artifactId>
-        <version>7.4.1-SNAPSHOT</version>
+        <version>8.0.5-SNAPSHOT</version>
         <extensions>true</extensions>
       </plugin>
     </plugins>
   </build>
-	
+  
 </project>

--- a/deploy/config-application/maven/config/pom.xml
+++ b/deploy/config-application/maven/config/pom.xml
@@ -32,8 +32,12 @@
       <plugin>
         <groupId>com.axonivy.ivy.ci</groupId>
         <artifactId>project-build-plugin</artifactId>
-        <version>8.0.5-SNAPSHOT</version>
+        <version>9.1.0-SNAPSHOT</version>
         <extensions>true</extensions>
+        <configuration>
+          <!-- 9.1.0 has not been released yet, using the nightly build -->
+          <engineDownloadUrl>https://developer.axonivy.com/permalink/nightly/axonivy-engine.zip</engineDownloadUrl>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/deploy/config-application/pom.xml
+++ b/deploy/config-application/pom.xml
@@ -44,7 +44,7 @@
 			<plugin>
 				<groupId>com.axonivy.ivy.ci</groupId>
 				<artifactId>project-build-plugin</artifactId>
-				<version>8.0.5-SNAPSHOT</version>
+				<version>9.1.0-SNAPSHOT</version>
 				<executions>
 					<execution>
 					<id>test.engine.starter</id> 

--- a/deploy/config-application/pom.xml
+++ b/deploy/config-application/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>ch.ivyteam.ivy.project.demo.ci.deploy.config-application</groupId>
 	<artifactId>config-application</artifactId>
-	<version>7.3.0-SNAPSHOT</version>
+	<version>9.1.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<scm>
@@ -44,7 +44,7 @@
 			<plugin>
 				<groupId>com.axonivy.ivy.ci</groupId>
 				<artifactId>project-build-plugin</artifactId>
-				<version>7.4.1-SNAPSHOT</version>
+				<version>8.0.5-SNAPSHOT</version>
 				<executions>
 					<execution>
 					<id>test.engine.starter</id> 

--- a/deploy/single-project-over-http/pom.xml
+++ b/deploy/single-project-over-http/pom.xml
@@ -18,9 +18,18 @@
 			<plugin>
 				<groupId>com.axonivy.ivy.ci</groupId>
 				<artifactId>project-build-plugin</artifactId>
-				<version>8.0.5-SNAPSHOT</version>
+				<version>9.1.0-SNAPSHOT</version>
 				<extensions>true</extensions>
 				<executions>
+					<execution>
+						<id>test.engine.download</id>
+						<phase>validate</phase>
+						<goals><goal>installEngine</goal></goals>
+						<configuration>
+							<!-- 9.1.0 has not been released yet, using the nightly build -->
+							<engineDownloadUrl>https://developer.axonivy.com/permalink/nightly/axonivy-engine.zip</engineDownloadUrl>
+						</configuration>
+					</execution>
 					<execution>
 						<id>test.engine.starter</id>
 						<phase>pre-integration-test</phase>

--- a/deploy/single-project-over-http/pom.xml
+++ b/deploy/single-project-over-http/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>ch.ivyteam.ivy.project.demo.ci</groupId>
 	<artifactId>deploy-single-over-http</artifactId>
-	<version>7.3.0-SNAPSHOT</version>
+	<version>9.1.0-SNAPSHOT</version>
 	<packaging>iar</packaging>
 
 	<properties>
@@ -18,7 +18,7 @@
 			<plugin>
 				<groupId>com.axonivy.ivy.ci</groupId>
 				<artifactId>project-build-plugin</artifactId>
-				<version>7.4.1-SNAPSHOT</version>
+				<version>8.0.5-SNAPSHOT</version>
 				<extensions>true</extensions>
 				<executions>
 					<execution>

--- a/deploy/single-project/pom.xml
+++ b/deploy/single-project/pom.xml
@@ -37,9 +37,18 @@
 			<plugin>
 				<groupId>com.axonivy.ivy.ci</groupId>
 				<artifactId>project-build-plugin</artifactId>
-				<version>8.0.5-SNAPSHOT</version>
+				<version>9.1.0-SNAPSHOT</version>
 				<extensions>true</extensions>
 				<executions>
+					<execution>
+						<id>test.engine.download</id>
+						<phase>validate</phase>
+						<goals><goal>installEngine</goal></goals>
+						<configuration>
+							<!-- 9.1.0 has not been released yet, using the nightly build -->
+							<engineDownloadUrl>https://developer.axonivy.com/permalink/nightly/axonivy-engine.zip</engineDownloadUrl>
+						</configuration>
+					</execution>
 					<execution>
 						<id>test.engine.starter</id>
 						<phase>pre-integration-test</phase>

--- a/deploy/single-project/pom.xml
+++ b/deploy/single-project/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>ch.ivyteam.ivy.project.demo.ci</groupId>
 	<artifactId>deploy-single</artifactId>
-	<version>7.3.0-SNAPSHOT</version>
+	<version>9.1.0-SNAPSHOT</version>
 	<packaging>iar</packaging>
 
 	<properties>
@@ -37,7 +37,7 @@
 			<plugin>
 				<groupId>com.axonivy.ivy.ci</groupId>
 				<artifactId>project-build-plugin</artifactId>
-				<version>7.4.1-SNAPSHOT</version>
+				<version>8.0.5-SNAPSHOT</version>
 				<extensions>true</extensions>
 				<executions>
 					<execution>


### PR DESCRIPTION
Build: https://jenkins.ivyteam.io/job/project-build-examples/job/bugfix%252FXIVY-3774_upgrade-build-plugin/

- compile-test projects were already version 9.1.0-SNAP just upgraded the plugin to 8.0.5-SNAP
- deploy projects were version 7.4.0-SNAP, upgraded it to 9.1.0-SNAP and the plugin to 8.0.5-SNAP

- I could combine **application/maven/config** and **config-application/maven/config** and move it to their root folder and have both projects reference that but it feels awkward in those examples so I left the duplication. Like this they are independent, any opinion?

- there isn't a 8.0 release branch yet, should I create one with version 8.0.5-SNAP? Or should I downgrade all projects from 9.1.0-SNAP to 8.0.5-SNAP? They use the build plugin 8.0.5-SNAP anyway. Don't know why it's already version 9.1.0-SNAP.
- The 8.0 and master would be the same except the versions. I personally would wait until the 9.1.0 engine release. (or we could use the nightly engine in the master branch and use the 9.1.0-SNAP build plugin)