### PR TITLE
Remove check version because it does not validated project-build-plugin

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,8 +33,7 @@ pipeline {
                   "-Divy.engine.list.url=${params.engineListUrl} " +
                   "-Divy.engine.version=[9.4.0,] " + 
                   "-Dmaven.test.failure.ignore=true " +
-                  "-Dselenide.remote=http://${seleniumName}:4444/wd/hub "
-                checkVersions()
+                  "-Dselenide.remote=http://${seleniumName}:4444/wd/hub "                
               }
             }
           } finally {


### PR DESCRIPTION
checkVersion should validate if there are new maven plugin updates. But in this repo we are only interested in the project-build-plugin. Because we don't have the time to update every week the fabric-8 plugin.

checkVersion can not filter for only the project build plugin. And anyway it does not properly work if the plugin is defined in a parent pom and the parent pom is not part as a module in the reactor build.

We should completely re-implement checkVersion. But I think its not important because we have a build job to update the project build plugin version everywhere.