### PR TITLE
XIVY-17305 fix: make classpath output match maven output

### DIFF
--- a/compile-test/crmIntegrationTests/.classpath
+++ b/compile-test/crmIntegrationTests/.classpath
@@ -40,5 +40,5 @@
 			<attribute name="owner.project.facets" value="java"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="output" path="classes"/>
+	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/deploy/application/base/.classpath
+++ b/deploy/application/base/.classpath
@@ -34,5 +34,5 @@
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="output" path="classes"/>
+	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/deploy/application/customer/.classpath
+++ b/deploy/application/customer/.classpath
@@ -34,5 +34,5 @@
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="output" path="classes"/>
+	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/deploy/application/solution/.classpath
+++ b/deploy/application/solution/.classpath
@@ -34,5 +34,5 @@
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="output" path="classes"/>
+	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/deploy/single-project-over-http/.classpath
+++ b/deploy/single-project-over-http/.classpath
@@ -26,5 +26,5 @@
 	<classpathentry kind="con" path="WEBAPP_CONTAINER"/>
 	<classpathentry kind="con" path="org.eclipse.jst.j2ee.internal.web.container"/>
 	<classpathentry exported="true" kind="lib" path="lib/ExternalLibraryForIssueXivy1571.jar"/>
-	<classpathentry kind="output" path="classes"/>
+	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/deploy/single-project/.classpath
+++ b/deploy/single-project/.classpath
@@ -30,5 +30,5 @@
 			<attribute name="owner.project.facets" value="java"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="output" path="classes"/>
+	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/docker/base/.classpath
+++ b/docker/base/.classpath
@@ -34,5 +34,5 @@
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="output" path="classes"/>
+	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/docker/customer/.classpath
+++ b/docker/customer/.classpath
@@ -34,5 +34,5 @@
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="output" path="classes"/>
+	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/docker/solution/.classpath
+++ b/docker/solution/.classpath
@@ -34,5 +34,5 @@
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="output" path="classes"/>
+	<classpathentry kind="output" path="target/classes"/>
 </classpath>


### PR DESCRIPTION
the problem with `<classpathentry kind="output" path="classes"/>` is that the engine will output .class files to classes dir but the build plugin will lookup for classes under target/classes during packaging because this is the default maven output.

we are aware of this mismatch between maven and classpath file and will take care of it.