### PR TITLE
fix compile test

### DIFF
--- a/compile-test/crm/pom.xml
+++ b/compile-test/crm/pom.xml
@@ -25,16 +25,11 @@
       <plugin>
         <groupId>com.axonivy.ivy.ci</groupId>
         <artifactId>project-build-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>default-unpack-libs</id>
-            <configuration>
-              <unpackIncludes>
-                <unpackExclude>lib/*.jar</unpackExclude>
-              </unpackIncludes>
-            </configuration>
-          </execution>
-        </executions>
+        <configuration>
+          <unpackIncludes>
+            <unpackInclude>lib/*.jar</unpackInclude>
+          </unpackIncludes>
+        </configuration>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
problem:
by default we only unpack libs located under lib/generated/rest/.*jar & lib_ws/client/*.jar.
.classpath file is not taken into account, in this case there would be:
`<classpathentry exported="true" kind="lib" path="lib/ExternalLibraryForIssueXivy1571.jar"/>`

fix:
specify in the build plugin to include lib/*.jar

question:
- should the default also consider jars under lib/*.jar?
- should we also start reading the .classpath file in the build plugin? (please no :D)